### PR TITLE
fix: default backspace handling

### DIFF
--- a/src/configs/handlers.ts
+++ b/src/configs/handlers.ts
@@ -29,7 +29,7 @@ export const keyCommandHandlers = (command: string, editorState: EditorState, ed
   const cursorIsAtFirst = cursorStart === 0 && cursorEnd === 0
 
   if (command === 'backspace') {
-    if (!editor.editorProps.onDelete?.(editorState)) {
+    if (editor.editorProps.onDelete && !editor.editorProps.onDelete?.(editorState)) {
       return 'handled'
     }
 


### PR DESCRIPTION
https://github.com/margox/braft-editor/blob/master/src/configs/handlers.js#L34

原版不提供onDelete时默认会走unhandle，现在这样会进handled 导致backspace 删不了东西