### PR TITLE
fix: gulp debug

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -115,8 +115,7 @@ export const createStateFromContent = (content, options: ConvertOptions = {}) =>
         'create'
       )
     }
-  }
-  if (typeof content === 'number') {
+  } else if (typeof content === 'number') {
     editorState = convertHTMLToEditorState(
       Number(content).toLocaleString().replace(/,/g, ''),
       getDecorators(customOptions.editorId),


### PR DESCRIPTION
给html 值时，永远会走到`typeof content !== 'number` else 分支，永远为空。这个pr修复了这个问题